### PR TITLE
Fix #silasmontgomery/vue-dynamic-select/issues/3

### DIFF
--- a/src/DynamicSelect.vue
+++ b/src/DynamicSelect.vue
@@ -87,10 +87,8 @@
             },
             value: function() {
                 // Load selected option on prop value change
-                this.options.forEach(option => {
-                    if(this.value && option[this.optionValue] == this.value[this.optionValue]) {
-                        this.selectedOption = option;
-                    }
+                this.selectedOption = this.options.find( option => {
+                    return this.value && option[this.optionValue] == this.value[this.optionValue];
                 })
             },
             selectedOption: function() {


### PR DESCRIPTION
When I pass a getter as `value` prop, and when the getter changes to null the dynamic-select doesn't reset

Related: https://github.com/silasmontgomery/vue-dynamic-select/issues/3